### PR TITLE
Fix format regex for hitem3d client

### DIFF
--- a/hitem3d_client.py
+++ b/hitem3d_client.py
@@ -51,7 +51,15 @@ def process_image_with_hitem3d(image_path: str, out_dir: str, prefer_formats=Non
 
         # Wait for generation & links
         deadline = time.time() + (wait_minutes * 60)
-        pat = re.compile(r'\.(?:' + "|".join([re.escape(ext) for ext in ["glb","obj","stl"]]) + r')$', re.I)
+        # Match any of the preferred extensions when scanning the page for
+        # downloadable links. Previously this was hard-coded to GLB/OBJ/STL,
+        # which meant supplying a different list via ``prefer_formats`` would
+        # have no effect. Build the pattern dynamically so callers can extend
+        # or override the formats.
+        pat = re.compile(
+            r"\.(?:" + "|".join([re.escape(ext) for ext in prefer_formats]) + r")$",
+            re.I,
+        )
 
         def find_href_links():
             anchors = page.eval_on_selector_all("a", "els => els.map(e => ({href: e.href, text: e.innerText}))")


### PR DESCRIPTION
## Summary
- use provided format list when searching for hitem3d download links

## Testing
- `python -m py_compile hitem3d_client.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689c472bdcd0832ebe2bf355496ab1b1