### PR TITLE
Log to file even on failure

### DIFF
--- a/app.py
+++ b/app.py
@@ -3,8 +3,7 @@ import logging
 import os
 from pathlib import Path
 from dotenv import load_dotenv
-from gemini_utils import generate_makerworld_idea, generate_image_with_imagen
-from hitem3d_client import process_image_with_hitem3d
+
 
 def main():
     parser = argparse.ArgumentParser(description="Idea → Imagen 4 → Hitem3D pipeline")
@@ -24,54 +23,63 @@ def main():
         level=logging.INFO,
         format="%(asctime)s %(levelname)s %(message)s",
         handlers=[
-            logging.FileHandler(out_dir / "run.log", mode="w", encoding="utf-8"),
+            logging.FileHandler(str(out_dir / "run.log"), mode="w", encoding="utf-8"),
             logging.StreamHandler(),
         ],
+        force=True,
     )
     logger = logging.getLogger(__name__)
 
-    # 1) Generate a MakerWorld-ready idea (if not provided)
-    if args.idea:
-        idea_text = args.idea.strip()
-    else:
-        idea_text = generate_makerworld_idea()
+    try:
+        from gemini_utils import generate_makerworld_idea, generate_image_with_imagen
+        from hitem3d_client import process_image_with_hitem3d
 
-    idea_path = out_dir / "idea.txt"
-    idea_path.write_text(idea_text, encoding="utf-8")
-    logger.info("[ok] Saved idea → %s", idea_path)
+        # 1) Generate a MakerWorld-ready idea (if not provided)
+        if args.idea:
+            idea_text = args.idea.strip()
+        else:
+            idea_text = generate_makerworld_idea()
 
-    # 2) Craft an image prompt if not provided
-    if args.image_prompt:
-        prompt = args.image_prompt.strip()
-    else:
-        prompt = (
-            "Clean orthographic/isometric studio render of the product described: "
-            f"{idea_text.splitlines()[0]} — minimalistic, neutral white background, "
-            "front or 3/4 view, sharp edges, even lighting, "
-            "no text, no branding, centered, high detail."
+        idea_path = out_dir / "idea.txt"
+        idea_path.write_text(idea_text, encoding="utf-8")
+        logger.info("[ok] Saved idea → %s", idea_path)
+
+        # 2) Craft an image prompt if not provided
+        if args.image_prompt:
+            prompt = args.image_prompt.strip()
+        else:
+            prompt = (
+                "Clean orthographic/isometric studio render of the product described: "
+                f"{idea_text.splitlines()[0]} — minimalistic, neutral white background, "
+                "front or 3/4 view, sharp edges, even lighting, "
+                "no text, no branding, centered, high detail."
+            )
+
+        # 2) Generate image with Imagen 4
+        img_path = out_dir / "imagen.png"
+        generate_image_with_imagen(prompt, img_path)
+        logger.info("[ok] Saved generated image → %s", img_path)
+
+        # 3) Upload to Hitem3D and download result(s)
+        formats = [f.strip().lower() for f in args.formats.split(",") if f.strip()]
+        downloaded = process_image_with_hitem3d(
+            image_path=str(img_path),
+            out_dir=str(out_dir),
+            prefer_formats=formats,
+            wait_minutes=args.timeout,
+            headless=not args.headful
         )
 
-    # 2) Generate image with Imagen 4
-    img_path = out_dir / "imagen.png"
-    generate_image_with_imagen(prompt, img_path)
-    logger.info("[ok] Saved generated image → %s", img_path)
+        if downloaded:
+            logger.info("[ok] Downloaded: %s", ", ".join(downloaded))
+        else:
+            logger.warning(
+                "[warn] No model files were downloaded. Try --headful to debug, increase --timeout, or check site requirements.",
+            )
+    except Exception:
+        logger.exception("[error] Pipeline failed")
+        raise
 
-    # 3) Upload to Hitem3D and download result(s)
-    formats = [f.strip().lower() for f in args.formats.split(",") if f.strip()]
-    downloaded = process_image_with_hitem3d(
-        image_path=str(img_path),
-        out_dir=str(out_dir),
-        prefer_formats=formats,
-        wait_minutes=args.timeout,
-        headless=not args.headful
-    )
-
-    if downloaded:
-        logger.info("[ok] Downloaded: %s", ", ".join(downloaded))
-    else:
-        logger.warning(
-            "[warn] No model files were downloaded. Try --headful to debug, increase --timeout, or check site requirements."
-        )
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- ensure logging writes to `run.log` by forcing configuration and using a file handler
- wrap the pipeline in a try/except block to record unexpected errors

## Testing
- `python -m py_compile app.py gemini_utils.py hitem3d_client.py`
- `python app.py --help`


------
https://chatgpt.com/codex/tasks/task_e_689c49b4add4832e8ee308dcf3575b00