### PR TITLE
Add web UI to launch pipeline from Codespaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,15 @@ Outputs land in `output/`:
 - `model.*` – one or more of GLB/OBJ/STL, depending on availability
 - `run.log` – log file for the latest run (overwritten each time)
 
+### Web interface (Codespaces)
+
+You can run the pipeline from a simple Flask web page.
+
+1. Install dependencies: `pip install -r requirements.txt`
+2. Start the server: `python server.py`
+3. In GitHub Codespaces, open the forwarded port (defaults to 8000) to view the page.
+4. Click **Run Pipeline** to launch `app.py`; logs stream from `output/run.log`.
+
 ---
 
 ## How it works

--- a/index.html
+++ b/index.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Image→3D Pipeline</title>
+</head>
+<body>
+  <button id="run">Run Pipeline</button>
+  <pre id="logs"></pre>
+  <script>
+    async function fetchLogs() {
+      const res = await fetch('/logs');
+      if (res.ok) {
+        document.getElementById('logs').textContent = await res.text();
+      }
+      setTimeout(fetchLogs, 1000);
+    }
+    document.getElementById('run').onclick = async () => {
+      await fetch('/run', {method: 'POST'});
+    };
+    fetchLogs();
+  </script>
+</body>
+</html>

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ Pillow>=10.4.0
 tenacity>=8.3.0
 tqdm>=4.66.4
 sift-stack-py
+Flask>=2.3.0

--- a/server.py
+++ b/server.py
@@ -1,0 +1,37 @@
+from flask import Flask, send_from_directory, jsonify
+import threading
+import subprocess
+from pathlib import Path
+import os
+
+app = Flask(__name__)
+_runner = None
+
+def _run_pipeline():
+    out_dir = Path('output')
+    out_dir.mkdir(exist_ok=True)
+    subprocess.run(['python', 'app.py'], check=False)
+
+@app.route('/')
+def index():
+    return send_from_directory('.', 'index.html')
+
+@app.post('/run')
+def run_pipeline():
+    global _runner
+    if _runner and _runner.is_alive():
+        return jsonify({'status': 'running'})
+    _runner = threading.Thread(target=_run_pipeline, daemon=True)
+    _runner.start()
+    return jsonify({'status': 'started'})
+
+@app.get('/logs')
+def get_logs():
+    log_path = Path('output/run.log')
+    if log_path.exists():
+        return log_path.read_text()
+    return '', 204
+
+if __name__ == '__main__':
+    port = int(os.environ.get('PORT', 8000))
+    app.run(host='0.0.0.0', port=port)


### PR DESCRIPTION
## Summary
- add Flask server and simple webpage to run `app.py` and stream logs
- document Codespaces web workflow
- include Flask in requirements

## Testing
- `python -m py_compile app.py server.py`
- `timeout 1 python server.py`


------
https://chatgpt.com/codex/tasks/task_e_689c608f5274832e889668b7160f7a6b